### PR TITLE
Split CMake generator and platform name

### DIFF
--- a/rdkafkaApp/src/Makefile
+++ b/rdkafkaApp/src/Makefile
@@ -19,7 +19,7 @@ ifneq ($(findstring linux,$(EPICS_HOST_ARCH)),)
 CMAKE_GENERATOR=Unix Makefiles
 else
 ifneq ($(findstring windows,$(EPICS_HOST_ARCH)),)
-VS_ARCH=$(VS_MAJOR) Win64
+VS_ARCH=$(VS_MAJOR)
 PLATFORM=x64
 CMAKE_CONFIG_FLAGS=$(CMAKE_CONFIG_FLAGS_WIN32)
 else
@@ -46,7 +46,7 @@ include $(TOP)/configure/RULES
 
 ifdef T_A
 install:
-	$(CMAKE) $(TOP)/librdkafka -G "$(CMAKE_GENERATOR)" -DCMAKE_INSTALL_PREFIX:PATH="$(INSTALL_DIR)" $(CMAKE_CONFIG_FLAGS)
+	$(CMAKE) $(TOP)/librdkafka -G "$(CMAKE_GENERATOR)" -A "$(PLATFORM)" -DCMAKE_INSTALL_PREFIX:PATH="$(INSTALL_DIR)" $(CMAKE_CONFIG_FLAGS)
 	$(CMAKE) --build . --target install --config $(CMAKE_CONFIG) $(CMAKE_BUILD_FLAGS)
 	-$(MKDIR) $(TOP)/bin
 	-$(MKDIR) $(TOP)/bin/$(EPICS_HOST_ARCH)


### PR DESCRIPTION
Part of ISISComputingGroup/IBEX#5173

In older version of CMake, the target platform could be specified at the end of the generator name. This syntax isn't supported anymore in generators for VS > 2017, so to support VS 2019 we need to specify the platform using the `-A` option. This option is backwards compatible with all older versions of the generator.